### PR TITLE
tasks/prereq: refspec can be empty if we are running test on master

### DIFF
--- a/tasks/prereq.yml
+++ b/tasks/prereq.yml
@@ -35,7 +35,7 @@
     update: yes
     dest: "{{ glusterfs_perf_git_dest | default('/usr/src/glusterfs') }}"
     repo: "{{ glusterfs_perf_git_repo | default('https://github.com/gluster/glusterfs.git') }}"
-    refspec: "{{ glusterfs_perf_git_refspec }}"
+    refspec: "{{ glusterfs_perf_git_refspec | default(omit) }}"
 
 - name: Clone smallfile perf git repository
   git:


### PR DESCRIPTION
If we are running nightly patches, then we will have refspec as empty string, because we would run on top of master.

If we need to do the particular patch test, then only provide refspec value.