### PR TITLE
more modifications to handle even github tags/version

### DIFF
--- a/playbooks/cluster_setup.yml
+++ b/playbooks/cluster_setup.yml
@@ -36,9 +36,10 @@
     gluster_infra_fw_state: enabled
     gluster_infra_fw_zone: public
 
-    # Point to the git repo you want to clone from
+    # Point to the git repo you want to clone from (and also the version/tag)
     #
     # glusterfs_perf_git_repo: https://review.gluster.org/glusterfs
+    # glusterfs_perf_git_version: release-6
 
     # check which refspec you need to fetch. If you want to test particular
     # patch, you would need to set it up. Remember to uncomment above variable
@@ -47,6 +48,8 @@
     #
     # glusterfs_perf_git_refspec: refs/changes/36/20636/21
 
+    #glusterfs_perf_resdir: /var/tmp/glusterperf/{{ansible_date_time.date}}-{{ glusterfs_perf_git_version | default('master') }}
+    glusterfs_perf_resdir: {{ lookup('pipe','date +%Y-%m-%d-%H-%M-%S') }}
     glusterfs_perf_volume: perfvol
     glusterfs_perf_bricks: /gluster_bricks/perfbrick
     glusterfs_perf_hosts: "{{ groups['all'] }}"

--- a/tasks/prereq.yml
+++ b/tasks/prereq.yml
@@ -35,6 +35,7 @@
     update: yes
     dest: "{{ glusterfs_perf_git_dest | default('/usr/src/glusterfs') }}"
     repo: "{{ glusterfs_perf_git_repo | default('https://github.com/gluster/glusterfs.git') }}"
+    version: "{{ glusterfs_perf_git_version | default('master') }}"
     refspec: "{{ glusterfs_perf_git_refspec | default(omit) }}"
 
 - name: Clone smallfile perf git repository


### PR DESCRIPTION
* also handle tasks/prereq: refspec can be empty if we are
  running test on master
* make res-dir to include refspec too, so we can differenciate
  between different runs