### PR TITLE
Rotate xaxis in graph and align perf results as table

### DIFF
--- a/plot/compare-and-plot.py
+++ b/plot/compare-and-plot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import os
 # has dependency of installing on fedora 'python3-matplotlib'
 import numpy as np
 import matplotlib as mpl
@@ -28,7 +29,10 @@ def plot_graph(bars1, bars2, plot_label, target_file, b1_label, b2_label):
     # Add xticks on the middle of the group bars
     plt.xlabel('group', fontweight='bold')
 
-    plt.xticks([r + barWidth for r in range(len(bars1))], plot_label)
+    plt.xticks([r + barWidth for r in range(len(bars1))], plot_label, rotation=90)
+
+    # Increase the bottom space
+    plt.subplots_adjust(bottom=0.3)
 
     # Create legend & Show graphic
     plt.legend()
@@ -74,7 +78,7 @@ def dump_results(ops, ref, t):
         b1.append(res)
         b2.append(cur)
         op.append(key)
-        print ("%s: %f -> %f (%f%%)" % (key, res, cur, ((cur - res) / res) * 100))
+        print ("%-15s %13f -> %13f %11f%%" % (key, res, cur, ((cur - res) / res) * 100))
 
     plot_graph(b1,b2, op, "%s/%s-%s.png" % (result_dir, t, ops[0]), t, current_tag)
 


### PR DESCRIPTION
Aligned results looks like this now,

```
==== Comparision from Tag: v5.0 to 2019-02-22 ====

create            1050.184420 ->   1121.324604    6.774066%
delete            2020.406500 ->   2519.378406   24.696610%
append            1166.633000 ->   1273.064184    9.122936%
overwrite         1246.115500 ->   1342.000157    7.694685%
rename             402.971800 ->    490.174182   21.639822%
mkdir             1056.783300 ->   1151.591566    8.971401%
rmdir             1554.033200 ->   2129.735948   37.045717%
symlink           2248.501000 ->   2851.497286   26.817701%
setxattr          2665.931900 ->   3607.386772   35.314288%
chmod             2115.130800 ->   2560.010820   21.033216%
delete-renamed    2075.904900 ->   2636.512033   27.005434%
read              2198.269300 ->   3254.721230   48.058349%
readdir           6106.614000 ->   6095.616121   -0.180098%
stat              2999.813700 ->   3802.392369   26.754284%
getxattr          6575.097500 ->   6656.370460    1.236072%
ls-l              2758.303400 ->   5999.937487  117.522753%
==== End of results ====
```

Signed-off-by: Aravinda VK <avishwan@redhat.com>